### PR TITLE
SDP: Bounds check 'id' parameter for free_sdp_slot()

### DIFF
--- a/btif/src/btif_sdp_server.c
+++ b/btif/src/btif_sdp_server.c
@@ -216,7 +216,8 @@ static int alloc_sdp_slot(bluetooth_sdp_record* in_record) {
 static int free_sdp_slot(int id) {
     int handle = -1;
     bluetooth_sdp_record* record = NULL;
-    if(id >= MAX_SDP_SLOTS) {
+    if (id < 0 || id >= MAX_SDP_SLOTS) {
+        android_errorWriteLog(0x534e4554, "37502513");
         APPL_TRACE_ERROR("%s() failed - id %d is invalid", __func__, id);
         return handle;
     }


### PR DESCRIPTION
Test: manual
Fixes: 37502513
Change-Id: I34e8296ec7ec6b4ffbe1fa0452754f2a421e6ec7
(cherry picked from commit b413f1b1365af4273647727e497848f95312d0ec)